### PR TITLE
Migrate to pydantic v2

### DIFF
--- a/.github/workflows/ci_check_dependencies.yaml
+++ b/.github/workflows/ci_check_dependencies.yaml
@@ -17,7 +17,5 @@ jobs:
       python_version: "3.10"
       install_extras: "[dev]"
       pr_labels: "CI/CD"
-      ignore: |
-        dependency-name=pydantic...update-types=version-update:semver-major
     secrets:
       PAT: ${{ secrets.CI_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ ci:
   autoupdate_branch: 'main'
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
   autoupdate_schedule: 'weekly'
-  skip: ['pylint']
   submodules: false
 
 # hooks
@@ -28,13 +27,14 @@ repos:
     - id: trailing-whitespace
       args: [--markdown-linebreak-ext=md]
 
-  # isort is a tool to sort and group import statements in Python files
+  # pyupgrade is a tool for automatically upgrading Python syntax for newer versions of
+  # the language
   # It works on files in-place
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
     hooks:
-    - id: isort
-      args: ["--profile", "black", "--filter-files", "--skip-gitignore"]
+    - id: pyupgrade
+      args: [--py310-plus]
 
   # Black is a code style and formatter
   # It works on files in-place
@@ -42,6 +42,22 @@ repos:
     rev: 23.12.0
     hooks:
     - id: black
+
+  # ruff is a Python linter, incl. import sorter and formatter
+  # It works partly on files in-place
+  # More information can be found in its documentation:
+  # https://docs.astral.sh/ruff/
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.8
+    hooks:
+    - id: ruff
+      # Fix what can be fixed in-place and exit with non-zero status if files were
+      # changed and/or there are rules violations.
+      args:
+      - "--fix"
+      - "--exit-non-zero-on-fix"
+      - "--show-fixes"
+      - "--no-unsafe-fixes"
 
   # Bandit is a security linter
   # More information can be found in its documentation:
@@ -62,36 +78,5 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies:
-        - "pydantic<2"
+        - "pydantic>=2"
         - "types-pyyaml"
-
-  - repo: local
-    hooks:
-    # pylint is a Python linter
-    # It is run through the local environment to ensure external packages can be
-    # imported without issue.
-    # For more information about pylint see its documentation at:
-    # https://pylint.pycqa.org/en/latest/
-    - id: pylint
-      name: pylint
-      entry: pylint
-      args: ["--rcfile=pyproject.toml"]
-      language: python
-      types: [python]
-      require_serial: true
-      exclude: ^tests/.*$
-    # pylint is a Python linter
-    # It is run through the local environment to ensure external packages can be
-    # imported without issue.
-    # For more information about pylint see its documentation at:
-    # https://pylint.pycqa.org/en/latest/
-    # - id: pylint-tests
-    #   name: pylint - tests
-    #   entry: pylint
-    #   args:
-    #   - "--rcfile=pyproject.toml"
-    #   - "--disable=import-outside-toplevel,redefined-outer-name"
-    #   language: python
-    #   types: [python]
-    #   require_serial: true
-    #   files: ^tests/.*$

--- a/deploy_on_onto_ns/__init__.py
+++ b/deploy_on_onto_ns/__init__.py
@@ -1,4 +1,6 @@
 """Deployment service for onto-ns.com"""
+from __future__ import annotations
+
 __version__ = "0.0.1"
 __author__ = "Casper Welzel Andersen"
 __author_email__ = "casper.w.andersen@sintef.no"

--- a/deploy_on_onto_ns/logger.py
+++ b/deploy_on_onto_ns/logger.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 from uvicorn.logging import DefaultFormatter
 
 if TYPE_CHECKING:  # pragma: no cover
-    # pylint: disable=ungrouped-imports
     import logging.handlers
 
 

--- a/deploy_on_onto_ns/logger.py
+++ b/deploy_on_onto_ns/logger.py
@@ -1,4 +1,6 @@
 """Logging to file."""
+from __future__ import annotations
+
 import logging
 import sys
 from contextlib import contextmanager

--- a/deploy_on_onto_ns/main.py
+++ b/deploy_on_onto_ns/main.py
@@ -1,8 +1,11 @@
 """The main application module."""
+from __future__ import annotations
+
 import os
 from asyncio import create_subprocess_shell, subprocess
 from pathlib import Path
 from shlex import quote
+from typing import Annotated
 
 import yaml
 from fastapi import FastAPI, HTTPException, Query, status
@@ -27,12 +30,14 @@ APP = FastAPI(
 
 @APP.get("/", response_model=DeployOnOntoNsResponse)
 async def deploy_service(
-    service: str = Query(..., description="The service to deploy"),
-    env: list[str] = Query(
-        [],
-        description="The environment variables to set for the deployment script.",
-        regex=r"^[A-Za-z_][A-Za-z0-9_]*=[^=]*$",
-    ),
+    service: Annotated[str, Query(description="The service to deploy")],
+    env: Annotated[
+        list[str],
+        Query(
+            description="The environment variables to set for the deployment script.",
+            pattern=r"^[A-Za-z_][A-Za-z0-9_]*=[^=]*$",
+        ),
+    ] = [],  # noqa: B006
 ) -> dict[str, str | int]:
     """Deploy `service` on onto-ns.com.
 

--- a/deploy_on_onto_ns/models.py
+++ b/deploy_on_onto_ns/models.py
@@ -1,7 +1,10 @@
 """Pydantic data models."""
-from pathlib import Path
+from __future__ import annotations
 
-from pydantic import field_validator, BaseModel, Field
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, Field, field_validator
 
 DEPLOYMENT_SCRIPTS = (
     Path(__file__).resolve().parent.parent.resolve() / "deployment_scripts"
@@ -11,9 +14,11 @@ DEPLOYMENT_SCRIPTS = (
 class DeployService(BaseModel):
     """A service to deploy on onto-ns.com."""
 
-    name: str = Field(..., description="The name of the service.")
-    script: Path = Field(..., description="The path to the deployment script.")
-    aliases: list[str] = Field([], description="The aliases for the service.")
+    name: Annotated[str, Field(description="The name of the service.")]
+    script: Annotated[Path, Field(description="The path to the deployment script.")]
+    aliases: Annotated[
+        list[str], Field(description="The aliases for the service.")
+    ] = []
 
     @field_validator("script", mode="after")
     @classmethod
@@ -33,9 +38,9 @@ class DeployService(BaseModel):
 class DeployServices(BaseModel):
     """The data model for the `deploy_services.yml` file."""
 
-    services: list[DeployService] = Field(
-        ..., description="The services available for deploy."
-    )
+    services: Annotated[
+        list[DeployService], Field(description="The services available for deploy.")
+    ]
 
     @field_validator("services", mode="after")
     @classmethod
@@ -50,7 +55,9 @@ class DeployServices(BaseModel):
 class DeployOnOntoNsResponse(BaseModel):
     """The response from the deployment service."""
 
-    returncode: int = Field(..., description="The return code from the deployment.")
-    service: str = Field(..., description="The service that was deployed.")
-    stdout: str = Field(..., description="The stdout from the deployment script.")
-    stderr: str = Field(..., description="The stderr from the deployment script.")
+    returncode: Annotated[
+        int, Field(description="The return code from the deployment.")
+    ]
+    service: Annotated[str, Field(description="The service that was deployed.")]
+    stdout: Annotated[str, Field(description="The stdout from the deployment script.")]
+    stderr: Annotated[str, Field(description="The stderr from the deployment script.")]

--- a/deploy_on_onto_ns/models.py
+++ b/deploy_on_onto_ns/models.py
@@ -1,7 +1,7 @@
 """Pydantic data models."""
 from pathlib import Path
 
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, BaseModel, Field
 
 DEPLOYMENT_SCRIPTS = (
     Path(__file__).resolve().parent.parent.resolve() / "deployment_scripts"
@@ -15,7 +15,8 @@ class DeployService(BaseModel):
     script: Path = Field(..., description="The path to the deployment script.")
     aliases: list[str] = Field([], description="The aliases for the service.")
 
-    @validator("script")
+    @field_validator("script", mode="after")
+    @classmethod
     def script_exists(cls, value: Path) -> Path:
         """Check that the deployment script exists."""
         if value.is_absolute():
@@ -36,7 +37,8 @@ class DeployServices(BaseModel):
         ..., description="The services available for deploy."
     )
 
-    @validator("services")
+    @field_validator("services", mode="after")
+    @classmethod
     def services_unique(cls, value: list[DeployService]) -> list[DeployService]:
         """Check that the services are unique."""
         names = [service.name for service in value]

--- a/deploy_on_onto_ns/uvicorn.py
+++ b/deploy_on_onto_ns/uvicorn.py
@@ -1,11 +1,15 @@
 """Customize running application with uvicorn."""
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
 from uvicorn.workers import UvicornWorker as OriginalUvicornWorker
 
 
 class UvicornWorker(OriginalUvicornWorker):
     """Uvicorn worker class to be used in production with gunicorn."""
 
-    CONFIG_KWARGS = {
+    CONFIG_KWARGS: ClassVar[dict[str, Any]] = {
         "server_header": False,
         "headers": [("Server", "Deploy on onto-ns.com")],
         "proxy_headers": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,31 +29,23 @@ dynamic = ["version", "description"]
 dependencies = [
     "fastapi ~=0.105.0",
     # "python-dotenv ~=1.0",
-    "pydantic <2",
+    "pydantic ~=2.5",
     "pyyaml ~=6.0",
     "uvicorn >=0.21.1,<1",
 ]
 
 [project.optional-dependencies]
-# docs = [
-#     "mike ~=1.1",
-#     "mkdocs ~=1.4",
-#     "mkdocs-awesome-pages-plugin ~=2.8",
-#     "mkdocs-material ~=9.1",
-#     "mkdocstrings[python-legacy] ~=0.20.0",
-# ]
 testing = [
     # "pytest ~=7.2",
     # "pytest-cov ~=4.0",
 ]
 dev = [
     "pre-commit ~=3.6",
-    "pylint ~=3.0",
 ]
 
 [project.urls]
 Home = "https://github.com/CasperWA/deploy-on-onto-ns"
-Documentation = "https://CasperWA.github.io/deploy-on-onto-ns"
+Documentation = "https://github.com/CasperWA/deploy-on-onto-ns?tab=readme-ov-file#readme"
 Source = "https://github.com/CasperWA/deploy-on-onto-ns"
 "Issue Tracker" = "https://github.com/CasperWA/deploy-on-onto-ns/issues"
 Changelog = "https://CasperWA.github.io/deploy-on-onto-ns/latest/CHANGELOG"
@@ -68,20 +60,38 @@ allow_redefinition = true
 check_untyped_defs = true
 plugins = ["pydantic.mypy"]
 
-[tool.pylint.messages_control]
-max-line-length = 88
-disable = [
-    "too-few-public-methods",
-    "no-name-in-module",
-    "no-self-argument",
+[tool.ruff.lint]
+extend-select = [
+    "E",  # pycodestyle
+    "F",  # Pyflakes
+    "B",  # flake8-bugbear
+    "I",  # isort
+    "BLE",  # flake8-blind-except
+    "ARG",  # flake8-unused-arguments
+    "C4",  # flake8-comprehensions
+    "ICN",  # flake8-import-conventions
+    "G",  # flake8-logging-format
+    "PGH",  # pygrep-hooks
+    "PIE",  # flake8-pie
+    "PL",  # pylint
+    "PT",  # flake8-pytest-style
+    "PTH",  # flake8-use-pathlib
+    "RET",  # flake8-return
+    "RUF",  # Ruff-specific
+    "SIM",  # flake8-simplify
+    "YTT",  # flake8-2020
+    "EXE",  # flake8-executable
+    "PYI",  # flake8-pyi
 ]
-max-args = 15
-max-branches = 15
+ignore = [
+    "PLR",  # Design related pylint codes
+    "PLW0127",  # pylint: Self-assignment of variables
+]
 
-# [tool.pytest.ini_options]
-# minversion = "7.0"
-# filterwarnings = [
-#     "ignore:.*imp module.*:DeprecationWarning",
-#     # Remove when invoke updates to `inspect.signature()` or similar:
-#     "ignore:.*inspect.getargspec().*:DeprecationWarning",
+# Import __future__.annotations for all Python files.
+isort.required-imports = ["from __future__ import annotations"]
+
+# [tool.ruff.lint.per-file-ignores]
+# "tests/**" = [
+#     "BLE",  # flake8-blind-except
 # ]


### PR DESCRIPTION
Closes #7 

Replaces pre-commit hooks `isort` and `pylint` with `pyupgrade` and `ruff`.

Update `ruff` linting rules in `pyproject.toml` in favor of `pylint`.

Use `bump-pydantic` to do the initial work of migrating to pydantic v2.
Then utilize `typing.Annotated` manually where possible, and ensure `field_validator` uses `"after"` mode.